### PR TITLE
Add buyer-facing pages and user role detection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,4 +17,5 @@ app.use("/user", userRouter)
 // DONT MISUSE THIS THANKYOU!!
 mongoose.connect('mongodb://localhost:27017/courses', { useNewUrlParser: true, useUnifiedTopology: true, dbName: "courses" });
 
-app.listen(3000, () => console.log('Server running on port 3000'));
+app.listen(3000, () => console.log("Server running on port 3000"));
+module.exports = app;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -3,6 +3,14 @@ const { authenticateJwt, SECRET } = require("../middleware/auth");
 const { User, Course, Admin } = require("../db");
 const router = express.Router();
 
+router.get('/me', authenticateJwt, async (req, res) => {
+  const user = await User.findOne({ username: req.user.username });
+  if (!user) {
+    return res.status(403).json({ msg: 'User not found' });
+  }
+  res.json({ username: user.username });
+});
+
   router.post('/signup', async (req, res) => {
     const { username, password } = req.body;
     const user = await User.findOne({ username });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,10 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Signin from "./components/Signin.jsx";
 import Signup from "./components/Signup.jsx";
+import UserSignin from "./components/UserSignin.jsx";
+import UserSignup from "./components/UserSignup.jsx";
+import UserCourses from "./components/UserCourses.jsx";
+import PurchasedCourses from "./components/PurchasedCourses.jsx";
 import Appbar from "./components/Appbar.jsx";
 import AddCourse from "./components/AddCourse.jsx";
 import Courses from "./components/Courses";
@@ -31,6 +35,10 @@ function App() {
                             <Route path={"/courses"} element={<Courses />} />
                             <Route path={"/signin"} element={<Signin />} />
                             <Route path={"/signup"} element={<Signup />} />
+                            <Route path={"/user/signin"} element={<UserSignin />} />
+                            <Route path={"/user/signup"} element={<UserSignup />} />
+                            <Route path={"/user/courses"} element={<UserCourses />} />
+                            <Route path={"/purchased"} element={<PurchasedCourses />} />
                             <Route path={"/"} element={<Landing />} />
                         </Routes>
                     </Router>
@@ -44,30 +52,26 @@ function InitUser() {
     const setUser = useSetRecoilState(userState);
     const init = async() => {
         try {
-            const response = await axios.get(`${BASE_URL}/admin/me`, {
-                headers: {
-                    "Authorization": "Bearer " + localStorage.getItem("token")
-                }
-            })
-
-            if (response.data.username) {
-                setUser({
-                    isLoading: false,
-                    userEmail: response.data.username
-                })
-            } else {
-                setUser({
-                    isLoading: false,
-                    userEmail: null
-                })
+            const adminRes = await axios.get(`${BASE_URL}/admin/me`, {
+                headers: { "Authorization": "Bearer " + localStorage.getItem("token") }
+            });
+            if (adminRes.data.username) {
+                setUser({ isLoading: false, userEmail: adminRes.data.username, role: 'admin' });
+                return;
             }
-        } catch (e) {
+        } catch (e) {}
 
-            setUser({
-                isLoading: false,
-                userEmail: null
-            })
-        }
+        try {
+            const userRes = await axios.get(`${BASE_URL}/user/me`, {
+                headers: { "Authorization": "Bearer " + localStorage.getItem("token") }
+            });
+            if (userRes.data.username) {
+                setUser({ isLoading: false, userEmail: userRes.data.username, role: 'user' });
+                return;
+            }
+        } catch (e) {}
+
+        setUser({ isLoading: false, userEmail: null, role: null });
     };
 
     useEffect(() => {

--- a/src/components/Appbar.jsx
+++ b/src/components/Appbar.jsx
@@ -5,11 +5,13 @@ import { isUserLoading } from "../store/selectors/isUserLoading";
 import {useSetRecoilState, useRecoilValue} from "recoil";
 import { userState } from "../store/atoms/user.js";
 import { userEmailState } from "../store/selectors/userEmail"
+import { userRoleState } from "../store/selectors/userRole"
 
 function Appbar({}) {
     const navigate = useNavigate()
     const userLoading = useRecoilValue(isUserLoading);
     const userEmail = useRecoilValue(userEmailState);
+    const userRole = useRecoilValue(userRoleState);
     const setUser = useSetRecoilState(userState);
 
     if (userLoading) {
@@ -28,24 +30,25 @@ function Appbar({}) {
             }}>
                 <Typography variant={"h6"}>Coursera</Typography>
             </div>
-    
+
             <div style={{display: "flex"}}>
                 <div style={{marginRight: 10, display: "flex"}}>
-                <div style={{marginRight: 10}}>
-                        <Button
-                            onClick={() => {
-                                navigate("/addcourse")
-                            }}
-                        >Add course</Button>
-                    </div>
-
+                {userRole === 'admin' && <>
                     <div style={{marginRight: 10}}>
-                        <Button
-                            onClick={() => {
-                                navigate("/courses")
-                            }}
-                        >Courses</Button>
+                        <Button onClick={() => { navigate("/addcourse") }}>Add course</Button>
                     </div>
+                    <div style={{marginRight: 10}}>
+                        <Button onClick={() => { navigate("/courses") }}>Courses</Button>
+                    </div>
+                </>}
+                {userRole === 'user' && <>
+                    <div style={{marginRight: 10}}>
+                        <Button onClick={() => { navigate("/user/courses") }}>Browse</Button>
+                    </div>
+                    <div style={{marginRight: 10}}>
+                        <Button onClick={() => { navigate("/purchased") }}>Purchased</Button>
+                    </div>
+                </>}
 
                     <Button
                         variant={"contained"}
@@ -53,7 +56,8 @@ function Appbar({}) {
                             localStorage.setItem("token", null);
                             setUser({
                                 isLoading: false,
-                                userEmail: null
+                                userEmail: null,
+                                role: null
                             })
                         }}
                     >Logout</Button>
@@ -77,9 +81,7 @@ function Appbar({}) {
                 <div style={{marginRight: 10}}>
                     <Button
                         variant={"contained"}
-                        onClick={() => {
-                            navigate("/signup")
-                        }}
+                        onClick={() => { navigate("/signup") }}
                     >Signup</Button>
                 </div>
                 <div>
@@ -89,6 +91,12 @@ function Appbar({}) {
                             navigate("/signin")
                         }}
                     >Signin</Button>
+                </div>
+                <div style={{marginLeft: 10}}>
+                    <Button variant={"contained"} onClick={() => { navigate("/user/signup") }}>User Signup</Button>
+                </div>
+                <div style={{marginLeft: 10}}>
+                    <Button variant={"contained"} onClick={() => { navigate("/user/signin") }}>User Signin</Button>
                 </div>
             </div>
         </div>

--- a/src/components/PurchasedCourses.jsx
+++ b/src/components/PurchasedCourses.jsx
@@ -1,0 +1,33 @@
+import { Card, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { BASE_URL } from '../config.js';
+
+function PurchasedCourses() {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    const init = async () => {
+      const res = await axios.get(`${BASE_URL}/user/purchasedCourses`, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+      });
+      setCourses(res.data.purchasedCourses);
+    };
+    init();
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
+      {courses.map((course) => (
+        <Card key={course._id} style={{ margin: 10, width: 300, padding: 20 }}>
+          <Typography variant='h5' textAlign={'center'}>
+            {course.title}
+          </Typography>
+          <img src={course.imageLink} style={{ width: 300 }} />
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export default PurchasedCourses;

--- a/src/components/UserCourses.jsx
+++ b/src/components/UserCourses.jsx
@@ -1,0 +1,52 @@
+import { Button, Card, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { BASE_URL } from '../config.js';
+
+function UserCourses() {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    const init = async () => {
+      const res = await axios.get(`${BASE_URL}/user/courses`, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+      });
+      setCourses(res.data.courses);
+    };
+    init();
+  }, []);
+
+  const purchase = async (id) => {
+    await axios.post(
+      `${BASE_URL}/user/courses/${id}`,
+      {},
+      {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+      }
+    );
+    alert('Purchased course');
+  };
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
+      {courses.map((course) => (
+        <Card key={course._id} style={{ margin: 10, width: 300, padding: 20 }}>
+          <Typography variant='h5' textAlign={'center'}>
+            {course.title}
+          </Typography>
+          <Typography variant='subtitle1' textAlign={'center'}>
+            {course.description}
+          </Typography>
+          <img src={course.imageLink} style={{ width: 300 }} />
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: 20 }}>
+            <Button variant='contained' onClick={() => purchase(course._id)}>
+              Buy
+            </Button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export default UserCourses;

--- a/src/components/UserSignin.jsx
+++ b/src/components/UserSignin.jsx
@@ -1,0 +1,77 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { Card, Typography } from '@mui/material';
+import { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { userState } from '../store/atoms/user.js';
+import { BASE_URL } from '../config.js';
+
+function UserSignin() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const setUser = useSetRecoilState(userState);
+
+  return (
+    <div>
+      <div
+        style={{
+          paddingTop: 150,
+          marginBottom: 10,
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant={'h6'}>Sign in to continue</Typography>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Card variant={'outlined'} style={{ width: 400, padding: 20 }}>
+          <TextField
+            onChange={(e) => setEmail(e.target.value)}
+            fullWidth
+            label='Email'
+            variant='outlined'
+          />
+          <br />
+          <br />
+          <TextField
+            onChange={(e) => setPassword(e.target.value)}
+            fullWidth
+            label='Password'
+            variant='outlined'
+            type='password'
+          />
+          <br />
+          <br />
+          <Button
+            size={'large'}
+            variant='contained'
+            onClick={async () => {
+              const res = await axios.post(
+                `${BASE_URL}/user/login`,
+                {
+                  username: email,
+                  password,
+                },
+                {
+                  headers: {
+                    'Content-type': 'application/json',
+                  },
+                }
+              );
+              localStorage.setItem('token', res.data.token);
+              setUser({ userEmail: email, role: 'user', isLoading: false });
+              navigate('/user/courses');
+            }}
+          >
+            Signin
+          </Button>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default UserSignin;

--- a/src/components/UserSignup.jsx
+++ b/src/components/UserSignup.jsx
@@ -1,0 +1,69 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { Card, Typography } from '@mui/material';
+import { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { userState } from '../store/atoms/user.js';
+import { BASE_URL } from '../config.js';
+
+function UserSignup() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const setUser = useSetRecoilState(userState);
+
+  return (
+    <div>
+      <div
+        style={{
+          paddingTop: 150,
+          marginBottom: 10,
+          display: 'flex',
+          justifyContent: 'center',
+        }}
+      >
+        <Typography variant={'h6'}>Create an account</Typography>
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <Card variant={'outlined'} style={{ width: 400, padding: 20 }}>
+          <TextField
+            onChange={(e) => setEmail(e.target.value)}
+            fullWidth
+            label='Email'
+            variant='outlined'
+          />
+          <br />
+          <br />
+          <TextField
+            onChange={(e) => setPassword(e.target.value)}
+            fullWidth
+            label='Password'
+            variant='outlined'
+            type='password'
+          />
+          <br />
+          <br />
+          <Button
+            size={'large'}
+            variant='contained'
+            onClick={async () => {
+              const res = await axios.post(`${BASE_URL}/user/signup`, {
+                username: email,
+                password,
+              });
+              localStorage.setItem('token', res.data.token);
+              setUser({ userEmail: email, role: 'user', isLoading: false });
+              navigate('/user/courses');
+            }}
+          >
+            Signup
+          </Button>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default UserSignup;

--- a/src/store/atoms/user.js
+++ b/src/store/atoms/user.js
@@ -4,6 +4,7 @@ export const userState = atom({
   key: 'userState',
   default: {
     isLoading: true,
-    userEmail: null
+    userEmail: null,
+    role: null
   },
 });

--- a/src/store/selectors/userRole.js
+++ b/src/store/selectors/userRole.js
@@ -1,0 +1,10 @@
+import { selector } from 'recoil';
+import { userState } from '../atoms/user';
+
+export const userRoleState = selector({
+  key: 'userRoleState',
+  get: ({ get }) => {
+    const state = get(userState);
+    return state.role;
+  },
+});


### PR DESCRIPTION
## Summary
- implement `/user/me` endpoint for checking logged-in buyers
- export Express app from server
- track user role in Recoil state
- add buyer signup/signin pages and pages to browse and purchase courses
- update AppBar navigation and routes for buyer flows

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm install`
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_684899ecbbb48322970a32da35ad4c37